### PR TITLE
fix: one line for workspaces in package.json

### DIFF
--- a/template/{{slug}}/package.json.jinja
+++ b/template/{{slug}}/package.json.jinja
@@ -2,8 +2,7 @@
   "name": "@datalayer/metarepo",
   "private": true,
   "workspaces": [
-    "packages/*",
-    {% if "jupyter-ui" in repos %}"packages/jupyter-ui/packages/react"{% endif %}
+    "packages/*"{% if "jupyter-ui" in repos %}, "packages/jupyter-ui/packages/react"{% endif %}
   ],
   "scripts": {
     "build": "lerna run --concurrency 1 build",


### PR DESCRIPTION
This should avoid an empty line in the package.json when the jupyter-ui repository is not selected in the Copier questionnaire. Fixes #16 